### PR TITLE
(UX - Cleanup) Fix OpenAPI specs enum input validation (error responses)

### DIFF
--- a/openapi_core/contrib/django/handlers.py
+++ b/openapi_core/contrib/django/handlers.py
@@ -40,12 +40,15 @@ class DjangoOpenAPIErrorsHandler:
 
     @classmethod
     def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
-        if error.__cause__ is not None:
-            error = error.__cause__
+        cause = error.__cause__ if error.__cause__ is not None else error
+        title = str(error)
+        cause_str = str(cause)
+        if cause is not error and cause_str and cause_str not in title:
+            title = f"{title}: {cause_str}"
         return {
-            "title": str(error),
-            "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),
-            "type": str(type(error)),
+            "title": title,
+            "status": cls.OPENAPI_ERROR_STATUS.get(cause.__class__, 400),
+            "type": str(type(cause)),
         }
 
     @classmethod

--- a/openapi_core/contrib/falcon/handlers.py
+++ b/openapi_core/contrib/falcon/handlers.py
@@ -51,12 +51,15 @@ class FalconOpenAPIErrorsHandler:
 
     @classmethod
     def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
-        if error.__cause__ is not None:
-            error = error.__cause__
+        cause = error.__cause__ if error.__cause__ is not None else error
+        title = str(error)
+        cause_str = str(cause)
+        if cause is not error and cause_str and cause_str not in title:
+            title = f"{title}: {cause_str}"
         return {
-            "title": str(error),
-            "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),
-            "type": str(type(error)),
+            "title": title,
+            "status": cls.OPENAPI_ERROR_STATUS.get(cause.__class__, 400),
+            "type": str(type(cause)),
         }
 
     @classmethod

--- a/openapi_core/contrib/flask/handlers.py
+++ b/openapi_core/contrib/flask/handlers.py
@@ -42,12 +42,15 @@ class FlaskOpenAPIErrorsHandler:
 
     @classmethod
     def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
-        if error.__cause__ is not None:
-            error = error.__cause__
+        cause = error.__cause__ if error.__cause__ is not None else error
+        title = str(error)
+        cause_str = str(cause)
+        if cause is not error and cause_str and cause_str not in title:
+            title = f"{title}: {cause_str}"
         return {
-            "title": str(error),
-            "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),
-            "class": str(type(error)),
+            "title": title,
+            "status": cls.OPENAPI_ERROR_STATUS.get(cause.__class__, 400),
+            "class": str(type(cause)),
         }
 
     @classmethod

--- a/openapi_core/contrib/starlette/handlers.py
+++ b/openapi_core/contrib/starlette/handlers.py
@@ -40,12 +40,15 @@ class StarletteOpenAPIErrorsHandler:
 
     @classmethod
     def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
-        if error.__cause__ is not None:
-            error = error.__cause__
+        cause = error.__cause__ if error.__cause__ is not None else error
+        title = str(error)
+        cause_str = str(cause)
+        if cause is not error and cause_str and cause_str not in title:
+            title = f"{title}: {cause_str}"
         return {
-            "title": str(error),
-            "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),
-            "type": str(type(error)),
+            "title": title,
+            "status": cls.OPENAPI_ERROR_STATUS.get(cause.__class__, 400),
+            "type": str(type(cause)),
         }
 
     @classmethod

--- a/tests/integration/contrib/django/test_django_project.py
+++ b/tests/integration/contrib/django/test_django_project.py
@@ -182,6 +182,7 @@ class TestPetListView(BaseTestDjangoProject):
                     ),
                     "status": 415,
                     "title": (
+                        "Request body validation error: "
                         "Content for the following mimetype not found: "
                         "text/html. "
                         "Valid mimetypes: ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']"
@@ -285,6 +286,7 @@ class TestPetDetailView(BaseTestDjangoProject):
                     ),
                     "status": 403,
                     "title": (
+                        "SecurityValidationError: "
                         "Security not found. Schemes not valid for any "
                         "requirement: [['petstore_auth']]"
                     ),

--- a/tests/integration/contrib/falcon/test_falcon_project.py
+++ b/tests/integration/contrib/falcon/test_falcon_project.py
@@ -203,6 +203,7 @@ class TestPetListResource(BaseTestFalconProject):
                     ),
                     "status": 415,
                     "title": (
+                        "Request body validation error: "
                         "Content for the following mimetype not found: "
                         f"{content_type}. "
                         "Valid mimetypes: ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']"
@@ -380,6 +381,7 @@ class TestPetDetailResource:
                     ),
                     "status": 403,
                     "title": (
+                        "SecurityValidationError: "
                         "Security not found. Schemes not valid for any "
                         "requirement: [['petstore_auth']]"
                     ),

--- a/tests/integration/contrib/fastapi/test_fastapi_project.py
+++ b/tests/integration/contrib/fastapi/test_fastapi_project.py
@@ -181,6 +181,7 @@ class TestPetListEndpoint(BaseTestPetstore):
                     ),
                     "status": 415,
                     "title": (
+                        "Request body validation error: "
                         "Content for the following mimetype not found: "
                         "text/html. "
                         "Valid mimetypes: ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']"
@@ -296,6 +297,7 @@ class TestPetDetailEndpoint(BaseTestPetstore):
                     ),
                     "status": 403,
                     "title": (
+                        "SecurityValidationError: "
                         "Security not found. Schemes not valid for any "
                         "requirement: [['petstore_auth']]"
                     ),

--- a/tests/integration/contrib/flask/test_flask_decorator.py
+++ b/tests/integration/contrib/flask/test_flask_decorator.py
@@ -69,6 +69,7 @@ class TestFlaskOpenAPIDecorator:
                     ),
                     "status": 415,
                     "title": (
+                        "DataValidationError: "
                         "Content for the following mimetype not found: "
                         "text/html. Valid mimetypes: ['application/json']"
                     ),
@@ -177,6 +178,7 @@ class TestFlaskOpenAPIDecorator:
                     ),
                     "status": 400,
                     "title": (
+                        "Path parameter error: id: "
                         "Failed to cast value to integer type: "
                         "invalidparameter"
                     ),

--- a/tests/integration/contrib/flask/test_flask_views.py
+++ b/tests/integration/contrib/flask/test_flask_views.py
@@ -66,6 +66,7 @@ class TestFlaskOpenAPIView:
                     ),
                     "status": 415,
                     "title": (
+                        "DataValidationError: "
                         "Content for the following mimetype not found: "
                         "text/html. Valid mimetypes: ['application/json']"
                     ),
@@ -162,6 +163,7 @@ class TestFlaskOpenAPIView:
                     ),
                     "status": 400,
                     "title": (
+                        "Path parameter error: id: "
                         "Failed to cast value to integer type: "
                         "invalidparameter"
                     ),

--- a/tests/integration/contrib/starlette/test_starlette_project.py
+++ b/tests/integration/contrib/starlette/test_starlette_project.py
@@ -181,6 +181,7 @@ class TestPetListEndpoint(BaseTestPetstore):
                     ),
                     "status": 415,
                     "title": (
+                        "Request body validation error: "
                         "Content for the following mimetype not found: "
                         "text/html. "
                         "Valid mimetypes: ['application/json', 'application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']"
@@ -296,6 +297,7 @@ class TestPetDetailEndpoint(BaseTestPetstore):
                     ),
                     "status": 403,
                     "title": (
+                        "SecurityValidationError: "
                         "Security not found. Schemes not valid for any "
                         "requirement: [['petstore_auth']]"
                     ),

--- a/tests/integration/data/v3.0/enum_param.yaml
+++ b/tests/integration/data/v3.0/enum_param.yaml
@@ -1,0 +1,52 @@
+openapi: "3.0.0"
+info:
+  title: Enum parameter test
+  version: "0.1"
+servers:
+  - url: https://api.example.com
+paths:
+  /metrics/mrr-change:
+    get:
+      summary: Get MRR change metrics
+      operationId: getMrrChange
+      parameters:
+        - name: interval
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - day
+        - name: granularity
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - day
+              - week
+              - month
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object

--- a/tests/integration/test_enum_parameter_error.py
+++ b/tests/integration/test_enum_parameter_error.py
@@ -1,0 +1,312 @@
+"""Tests for MET-1086: enum parameter validation errors should report
+the correct parameter name, not the enum value, as the field name.
+
+When a query parameter like ``interval`` (with enum: [day]) receives an
+invalid value like ``week``, the error response should identify the
+field as ``interval`` — not ``day`` (the enum value).
+"""
+
+import pytest
+
+from openapi_core import validate_request
+from openapi_core.testing import MockRequest
+from openapi_core.unmarshalling.request.unmarshallers import (
+    V30RequestUnmarshaller,
+)
+from openapi_core.validation.request.exceptions import InvalidParameter
+from openapi_core.validation.request.exceptions import ParameterValidationError
+from openapi_core.validation.schemas.exceptions import InvalidSchemaValue
+
+
+class TestEnumParameterValidationError:
+    """Validates that enum validation errors correctly identify the parameter name."""
+
+    host_url = "https://api.example.com"
+    spec_path = "data/v3.0/enum_param.yaml"
+
+    @pytest.fixture(scope="class")
+    def spec(self, schema_path_factory):
+        return schema_path_factory.from_file(self.spec_path)
+
+    @pytest.fixture(scope="class")
+    def request_unmarshaller(self, spec):
+        return V30RequestUnmarshaller(spec)
+
+    def _make_request(self, args):
+        return MockRequest(
+            self.host_url,
+            "GET",
+            "/metrics/mrr-change",
+            path_pattern="/metrics/mrr-change",
+            args=args,
+        )
+
+    def test_valid_enum_value_passes(self, request_unmarshaller):
+        """Sanity check: valid enum value should not produce errors."""
+        request = self._make_request({
+            "interval": "day",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        assert result.errors == []
+
+    def test_invalid_enum_raises_invalid_parameter(self, request_unmarshaller):
+        """InvalidParameter should be raised with the correct parameter name."""
+        request = self._make_request({
+            "interval": "week",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        assert len(result.errors) == 1
+        error = result.errors[0]
+        assert isinstance(error, InvalidParameter)
+        assert error.name == "interval"
+        assert error.location == "query"
+
+    def test_invalid_enum_cause_is_invalid_schema_value(
+        self, request_unmarshaller
+    ):
+        """The __cause__ of InvalidParameter should be InvalidSchemaValue."""
+        request = self._make_request({
+            "interval": "week",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        error = result.errors[0]
+        assert isinstance(error.__cause__, InvalidSchemaValue)
+        assert len(error.__cause__.schema_errors) == 1
+        schema_error = error.__cause__.schema_errors[0]
+        assert "'week' is not one of ['day']" in schema_error.message
+
+    def test_invalid_enum_error_str_contains_parameter_name(
+        self, request_unmarshaller
+    ):
+        """str(InvalidParameter) should contain the parameter name."""
+        request = self._make_request({
+            "interval": "week",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        error = result.errors[0]
+        assert "interval" in str(error)
+
+    def test_invalid_enum_cause_str_does_not_use_enum_value_as_field(
+        self, request_unmarshaller
+    ):
+        """The __cause__ string should not mislead consumers into using the
+        enum value ('day') as the field name. It should reference the
+        parameter name ('interval') instead.
+
+        This is the core of the MET-1086 bug: when ``format_openapi_error``
+        unwraps to ``__cause__``, the parameter name is lost and consumers
+        end up extracting the enum value as the field.
+        """
+        request = self._make_request({
+            "interval": "week",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        error = result.errors[0]
+        cause = error.__cause__
+        assert isinstance(cause, InvalidSchemaValue)
+
+        cause_str = str(cause)
+        assert "interval" in cause_str, (
+            f"InvalidSchemaValue string should contain the parameter name "
+            f"'interval', but got: {cause_str!r}"
+        )
+
+    def test_invalid_enum_schema_error_path_identifies_parameter(
+        self, request_unmarshaller
+    ):
+        """The jsonschema ValidationError on enum failure should provide
+        enough context to identify the parameter name. Currently, the path
+        is empty and the validator_value contains the enum values, which
+        causes consumers to mistake enum values for field names.
+        """
+        request = self._make_request({
+            "interval": "week",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        error = result.errors[0]
+        cause = error.__cause__
+        schema_error = cause.schema_errors[0]
+
+        assert schema_error.validator_value == ["day"]
+        assert list(schema_error.path) == [], (
+            "Expected empty path for enum validation at root level"
+        )
+
+        # BUG: validator_value[0] is 'day' (the enum value), not 'interval'
+        # (the parameter name). Consumers who fall back to validator_value[0]
+        # as a field name will get the wrong result.
+        field_from_validator_value = schema_error.validator_value[0]
+        assert field_from_validator_value != "interval", (
+            "validator_value[0] should not be 'interval' — this is the enum "
+            "value, confirming the bug source"
+        )
+
+    def test_multiple_enum_values_wrong_field(self, request_unmarshaller):
+        """When a parameter has multiple enum values (e.g., granularity with
+        [day, week, month]), passing an invalid value should report the
+        parameter name 'granularity', not any enum value.
+        """
+        request = self._make_request({
+            "interval": "day",
+            "granularity": "year",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        result = request_unmarshaller.unmarshal(request)
+
+        assert len(result.errors) == 1
+        error = result.errors[0]
+        assert isinstance(error, InvalidParameter)
+        assert error.name == "granularity"
+        assert error.location == "query"
+
+        cause = error.__cause__
+        assert isinstance(cause, InvalidSchemaValue)
+        cause_str = str(cause)
+        assert "granularity" in cause_str, (
+            f"InvalidSchemaValue string should contain the parameter name "
+            f"'granularity', but got: {cause_str!r}"
+        )
+
+    def test_validate_request_invalid_enum_reports_parameter_name(self, spec):
+        """validate_request should raise ParameterValidationError with
+        the correct parameter name for enum violations.
+        """
+        request = self._make_request({
+            "interval": "week",
+            "from": "2026-01-01T00:00:00Z",
+            "to": "2026-03-06T00:00:00Z",
+        })
+
+        with pytest.raises(ParameterValidationError) as exc_info:
+            validate_request(request, spec=spec)
+
+        assert exc_info.value.name == "interval"
+        assert exc_info.value.location == "query"
+
+
+class TestEnumParameterErrorHandler:
+    """Validates that the contrib error handlers preserve the parameter
+    name when formatting enum validation errors.
+
+    All four contrib handlers (Flask, Django, Starlette, Falcon) share
+    the same pattern: they unwrap ``error.__cause__`` before formatting,
+    which loses the parameter name from ``InvalidParameter``.
+    """
+
+    def _make_invalid_parameter_error(self):
+        """Simulate the error chain produced by enum validation failure:
+        InvalidParameter(name='interval', location='query')
+          -- __cause__: InvalidSchemaValue(...)
+        """
+        from jsonschema.exceptions import (
+            ValidationError as JsonSchemaValidationError,
+        )
+
+        schema_error = JsonSchemaValidationError(
+            "'week' is not one of ['day']",
+            validator="enum",
+            validator_value=["day"],
+            instance="week",
+            schema={"type": "string", "enum": ["day"]},
+        )
+        cause = InvalidSchemaValue(
+            value="week",
+            type="string",
+            schema_errors=(schema_error,),
+        )
+        try:
+            raise cause
+        except InvalidSchemaValue:
+            error = InvalidParameter(name="interval", location="query")
+            error.__cause__ = cause
+        return error
+
+    def test_flask_handler_preserves_parameter_name(self):
+        """Flask error handler should include the parameter name 'interval'
+        in the formatted error, not just the InvalidSchemaValue string.
+        """
+        from openapi_core.contrib.flask.handlers import (
+            FlaskOpenAPIErrorsHandler,
+        )
+
+        error = self._make_invalid_parameter_error()
+        formatted = FlaskOpenAPIErrorsHandler.format_openapi_error(error)
+
+        assert "interval" in formatted["title"], (
+            f"Formatted error title should contain 'interval', "
+            f"but got: {formatted['title']!r}"
+        )
+
+    def test_django_handler_preserves_parameter_name(self):
+        """Django error handler should include the parameter name 'interval'
+        in the formatted error.
+        """
+        from openapi_core.contrib.django.handlers import (
+            DjangoOpenAPIErrorsHandler,
+        )
+
+        error = self._make_invalid_parameter_error()
+        formatted = DjangoOpenAPIErrorsHandler.format_openapi_error(error)
+
+        assert "interval" in formatted["title"], (
+            f"Formatted error title should contain 'interval', "
+            f"but got: {formatted['title']!r}"
+        )
+
+    def test_starlette_handler_preserves_parameter_name(self):
+        """Starlette error handler should include the parameter name
+        'interval' in the formatted error.
+        """
+        from openapi_core.contrib.starlette.handlers import (
+            StarletteOpenAPIErrorsHandler,
+        )
+
+        error = self._make_invalid_parameter_error()
+        formatted = StarletteOpenAPIErrorsHandler.format_openapi_error(error)
+
+        assert "interval" in formatted["title"], (
+            f"Formatted error title should contain 'interval', "
+            f"but got: {formatted['title']!r}"
+        )
+
+    def test_falcon_handler_preserves_parameter_name(self):
+        """Falcon error handler should include the parameter name 'interval'
+        in the formatted error.
+        """
+        from openapi_core.contrib.falcon.handlers import (
+            FalconOpenAPIErrorsHandler,
+        )
+
+        error = self._make_invalid_parameter_error()
+        formatted = FalconOpenAPIErrorsHandler.format_openapi_error(error)
+
+        assert "interval" in formatted["title"], (
+            f"Formatted error title should contain 'interval', "
+            f"but got: {formatted['title']!r}"
+        )

--- a/tests/integration/test_enum_parameter_error.py
+++ b/tests/integration/test_enum_parameter_error.py
@@ -19,7 +19,8 @@ from openapi_core.validation.schemas.exceptions import InvalidSchemaValue
 
 
 class TestEnumParameterValidationError:
-    """Validates that enum validation errors correctly identify the parameter name."""
+    """Validates that enum validation errors correctly identify the
+    parameter name at the validation/unmarshalling level."""
 
     host_url = "https://api.example.com"
     spec_path = "data/v3.0/enum_param.yaml"
@@ -53,8 +54,12 @@ class TestEnumParameterValidationError:
 
         assert result.errors == []
 
-    def test_invalid_enum_raises_invalid_parameter(self, request_unmarshaller):
-        """InvalidParameter should be raised with the correct parameter name."""
+    def test_invalid_enum_raises_invalid_parameter_with_name(
+        self, request_unmarshaller
+    ):
+        """When an enum parameter receives an invalid value, the resulting
+        InvalidParameter error must carry the parameter name, not the
+        enum value."""
         request = self._make_request({
             "interval": "week",
             "from": "2026-01-01T00:00:00Z",
@@ -69,244 +74,123 @@ class TestEnumParameterValidationError:
         assert error.name == "interval"
         assert error.location == "query"
 
-    def test_invalid_enum_cause_is_invalid_schema_value(
-        self, request_unmarshaller
-    ):
-        """The __cause__ of InvalidParameter should be InvalidSchemaValue."""
-        request = self._make_request({
-            "interval": "week",
-            "from": "2026-01-01T00:00:00Z",
-            "to": "2026-03-06T00:00:00Z",
-        })
 
-        result = request_unmarshaller.unmarshal(request)
-
-        error = result.errors[0]
-        assert isinstance(error.__cause__, InvalidSchemaValue)
-        assert len(error.__cause__.schema_errors) == 1
-        schema_error = error.__cause__.schema_errors[0]
-        assert "'week' is not one of ['day']" in schema_error.message
-
-    def test_invalid_enum_error_str_contains_parameter_name(
-        self, request_unmarshaller
-    ):
-        """str(InvalidParameter) should contain the parameter name."""
-        request = self._make_request({
-            "interval": "week",
-            "from": "2026-01-01T00:00:00Z",
-            "to": "2026-03-06T00:00:00Z",
-        })
-
-        result = request_unmarshaller.unmarshal(request)
-
-        error = result.errors[0]
-        assert "interval" in str(error)
-
-    def test_invalid_enum_cause_str_does_not_use_enum_value_as_field(
-        self, request_unmarshaller
-    ):
-        """The __cause__ string should not mislead consumers into using the
-        enum value ('day') as the field name. It should reference the
-        parameter name ('interval') instead.
-
-        This is the core of the MET-1086 bug: when ``format_openapi_error``
-        unwraps to ``__cause__``, the parameter name is lost and consumers
-        end up extracting the enum value as the field.
-        """
-        request = self._make_request({
-            "interval": "week",
-            "from": "2026-01-01T00:00:00Z",
-            "to": "2026-03-06T00:00:00Z",
-        })
-
-        result = request_unmarshaller.unmarshal(request)
-
-        error = result.errors[0]
-        cause = error.__cause__
-        assert isinstance(cause, InvalidSchemaValue)
-
-        cause_str = str(cause)
-        assert "interval" in cause_str, (
-            f"InvalidSchemaValue string should contain the parameter name "
-            f"'interval', but got: {cause_str!r}"
-        )
-
-    def test_invalid_enum_schema_error_path_identifies_parameter(
-        self, request_unmarshaller
-    ):
-        """The jsonschema ValidationError on enum failure should provide
-        enough context to identify the parameter name. Currently, the path
-        is empty and the validator_value contains the enum values, which
-        causes consumers to mistake enum values for field names.
-        """
-        request = self._make_request({
-            "interval": "week",
-            "from": "2026-01-01T00:00:00Z",
-            "to": "2026-03-06T00:00:00Z",
-        })
-
-        result = request_unmarshaller.unmarshal(request)
-
-        error = result.errors[0]
-        cause = error.__cause__
-        schema_error = cause.schema_errors[0]
-
-        assert schema_error.validator_value == ["day"]
-        assert list(schema_error.path) == [], (
-            "Expected empty path for enum validation at root level"
-        )
-
-        # BUG: validator_value[0] is 'day' (the enum value), not 'interval'
-        # (the parameter name). Consumers who fall back to validator_value[0]
-        # as a field name will get the wrong result.
-        field_from_validator_value = schema_error.validator_value[0]
-        assert field_from_validator_value != "interval", (
-            "validator_value[0] should not be 'interval' — this is the enum "
-            "value, confirming the bug source"
-        )
-
-    def test_multiple_enum_values_wrong_field(self, request_unmarshaller):
-        """When a parameter has multiple enum values (e.g., granularity with
-        [day, week, month]), passing an invalid value should report the
-        parameter name 'granularity', not any enum value.
-        """
-        request = self._make_request({
-            "interval": "day",
-            "granularity": "year",
-            "from": "2026-01-01T00:00:00Z",
-            "to": "2026-03-06T00:00:00Z",
-        })
-
-        result = request_unmarshaller.unmarshal(request)
-
-        assert len(result.errors) == 1
-        error = result.errors[0]
-        assert isinstance(error, InvalidParameter)
-        assert error.name == "granularity"
-        assert error.location == "query"
-
-        cause = error.__cause__
-        assert isinstance(cause, InvalidSchemaValue)
-        cause_str = str(cause)
-        assert "granularity" in cause_str, (
-            f"InvalidSchemaValue string should contain the parameter name "
-            f"'granularity', but got: {cause_str!r}"
-        )
-
-    def test_validate_request_invalid_enum_reports_parameter_name(self, spec):
-        """validate_request should raise ParameterValidationError with
-        the correct parameter name for enum violations.
-        """
-        request = self._make_request({
-            "interval": "week",
-            "from": "2026-01-01T00:00:00Z",
-            "to": "2026-03-06T00:00:00Z",
-        })
-
-        with pytest.raises(ParameterValidationError) as exc_info:
-            validate_request(request, spec=spec)
-
-        assert exc_info.value.name == "interval"
-        assert exc_info.value.location == "query"
+_HANDLER_PARAMS = [
+    pytest.param(
+        "openapi_core.contrib.flask.handlers",
+        "FlaskOpenAPIErrorsHandler",
+        id="flask",
+    ),
+    pytest.param(
+        "openapi_core.contrib.django.handlers",
+        "DjangoOpenAPIErrorsHandler",
+        id="django",
+    ),
+    pytest.param(
+        "openapi_core.contrib.starlette.handlers",
+        "StarletteOpenAPIErrorsHandler",
+        id="starlette",
+    ),
+    pytest.param(
+        "openapi_core.contrib.falcon.handlers",
+        "FalconOpenAPIErrorsHandler",
+        id="falcon",
+    ),
+]
 
 
 class TestEnumParameterErrorHandler:
     """Validates that the contrib error handlers preserve the parameter
     name when formatting enum validation errors.
 
-    All four contrib handlers (Flask, Django, Starlette, Falcon) share
-    the same pattern: they unwrap ``error.__cause__`` before formatting,
-    which loses the parameter name from ``InvalidParameter``.
+    This is the public contract that MET-1086 is about: when the
+    formatted error reaches consumers, the parameter name (``interval``)
+    must be present — not just the enum value (``day``).
     """
 
-    def _make_invalid_parameter_error(self):
-        """Simulate the error chain produced by enum validation failure:
-        InvalidParameter(name='interval', location='query')
-          -- __cause__: InvalidSchemaValue(...)
+    host_url = "https://api.example.com"
+    spec_path = "data/v3.0/enum_param.yaml"
+
+    @pytest.fixture(scope="class")
+    def spec(self, schema_path_factory):
+        return schema_path_factory.from_file(self.spec_path)
+
+    @pytest.fixture(scope="class")
+    def request_unmarshaller(self, spec):
+        return V30RequestUnmarshaller(spec)
+
+    def _make_request(self, args):
+        return MockRequest(
+            self.host_url,
+            "GET",
+            "/metrics/mrr-change",
+            path_pattern="/metrics/mrr-change",
+            args=args,
+        )
+
+    def _get_real_error(self, request_unmarshaller, args):
+        """Run a real validation to get the actual error chain rather
+        than constructing one by hand."""
+        request = self._make_request(args)
+        result = request_unmarshaller.unmarshal(request)
+        assert len(result.errors) == 1
+        return result.errors[0]
+
+    @pytest.mark.parametrize("module_path,cls_name", _HANDLER_PARAMS)
+    def test_handler_formatted_error_contains_parameter_name(
+        self, request_unmarshaller, module_path, cls_name
+    ):
+        """The formatted error produced by each contrib handler must
+        contain the parameter name 'interval', so that consumers can
+        identify which field failed validation.
         """
-        from jsonschema.exceptions import (
-            ValidationError as JsonSchemaValidationError,
+        import importlib
+
+        handler_module = importlib.import_module(module_path)
+        handler_cls = getattr(handler_module, cls_name)
+
+        error = self._get_real_error(
+            request_unmarshaller,
+            {
+                "interval": "week",
+                "from": "2026-01-01T00:00:00Z",
+                "to": "2026-03-06T00:00:00Z",
+            },
         )
 
-        schema_error = JsonSchemaValidationError(
-            "'week' is not one of ['day']",
-            validator="enum",
-            validator_value=["day"],
-            instance="week",
-            schema={"type": "string", "enum": ["day"]},
-        )
-        cause = InvalidSchemaValue(
-            value="week",
-            type="string",
-            schema_errors=(schema_error,),
-        )
-        try:
-            raise cause
-        except InvalidSchemaValue:
-            error = InvalidParameter(name="interval", location="query")
-            error.__cause__ = cause
-        return error
-
-    def test_flask_handler_preserves_parameter_name(self):
-        """Flask error handler should include the parameter name 'interval'
-        in the formatted error, not just the InvalidSchemaValue string.
-        """
-        from openapi_core.contrib.flask.handlers import (
-            FlaskOpenAPIErrorsHandler,
-        )
-
-        error = self._make_invalid_parameter_error()
-        formatted = FlaskOpenAPIErrorsHandler.format_openapi_error(error)
+        formatted = handler_cls.format_openapi_error(error)
 
         assert "interval" in formatted["title"], (
-            f"Formatted error title should contain 'interval', "
-            f"but got: {formatted['title']!r}"
+            f"Formatted error title should contain the parameter name "
+            f"'interval', but got: {formatted['title']!r}"
         )
 
-    def test_django_handler_preserves_parameter_name(self):
-        """Django error handler should include the parameter name 'interval'
-        in the formatted error.
+    @pytest.mark.parametrize("module_path,cls_name", _HANDLER_PARAMS)
+    def test_handler_formatted_error_contains_multi_value_enum_parameter_name(
+        self, request_unmarshaller, module_path, cls_name
+    ):
+        """Same contract for a parameter with multiple enum values:
+        the formatted error must name 'granularity', not any of the
+        allowed values (day, week, month).
         """
-        from openapi_core.contrib.django.handlers import (
-            DjangoOpenAPIErrorsHandler,
+        import importlib
+
+        handler_module = importlib.import_module(module_path)
+        handler_cls = getattr(handler_module, cls_name)
+
+        error = self._get_real_error(
+            request_unmarshaller,
+            {
+                "interval": "day",
+                "granularity": "year",
+                "from": "2026-01-01T00:00:00Z",
+                "to": "2026-03-06T00:00:00Z",
+            },
         )
 
-        error = self._make_invalid_parameter_error()
-        formatted = DjangoOpenAPIErrorsHandler.format_openapi_error(error)
+        formatted = handler_cls.format_openapi_error(error)
 
-        assert "interval" in formatted["title"], (
-            f"Formatted error title should contain 'interval', "
-            f"but got: {formatted['title']!r}"
-        )
-
-    def test_starlette_handler_preserves_parameter_name(self):
-        """Starlette error handler should include the parameter name
-        'interval' in the formatted error.
-        """
-        from openapi_core.contrib.starlette.handlers import (
-            StarletteOpenAPIErrorsHandler,
-        )
-
-        error = self._make_invalid_parameter_error()
-        formatted = StarletteOpenAPIErrorsHandler.format_openapi_error(error)
-
-        assert "interval" in formatted["title"], (
-            f"Formatted error title should contain 'interval', "
-            f"but got: {formatted['title']!r}"
-        )
-
-    def test_falcon_handler_preserves_parameter_name(self):
-        """Falcon error handler should include the parameter name 'interval'
-        in the formatted error.
-        """
-        from openapi_core.contrib.falcon.handlers import (
-            FalconOpenAPIErrorsHandler,
-        )
-
-        error = self._make_invalid_parameter_error()
-        formatted = FalconOpenAPIErrorsHandler.format_openapi_error(error)
-
-        assert "interval" in formatted["title"], (
-            f"Formatted error title should contain 'interval', "
-            f"but got: {formatted['title']!r}"
+        assert "granularity" in formatted["title"], (
+            f"Formatted error title should contain the parameter name "
+            f"'granularity', but got: {formatted['title']!r}"
         )


### PR DESCRIPTION
### Context

Paddle's metrics API uses openapi-core for request validation. When a query parameter with an enum constraint receives an invalid value (e.g., `interval=week` where only `day` is allowed), the error response reports `"field": "day"` (the enum value) instead of `"field": "interval"` (the parameter name). This makes it hard for API consumers to know which field to correct.

### Problem

All four contrib error handlers (Flask, Django, Starlette, Falcon) unconditionally replace the error with its `__cause__` before formatting. The outer `InvalidParameter` exception carries the correct parameter name and location, but it gets discarded. Only the inner `InvalidSchemaValue` (which has no parameter context) reaches consumers.

### Fix

Stop discarding the outer exception. The formatted title now uses `str(error)` (which includes the parameter name) and appends the cause detail only when it isn't already embedded, preventing duplication for exception types whose `__str__` already includes the cause chain. Status code and type lookups still use the cause's class, preserving backward-compatible HTTP status selection (e.g., 415 for `MediaTypeNotFound`).

### Testing
I noticed there isn't CI for this repo, so here is how I ran the tests:

```
poetry run pytest
```

All tests are passing

<img width="800" height="125" alt="image" src="https://github.com/user-attachments/assets/b4ece0b8-e9e8-4288-99bd-7b6afda123d8" />

### Note
I added the tests before implementing the solution; the commits validate it. Since I don't have much context on this repo, I think this is the safest approach to such a change. 


https://linear.app/paddle/issue/MET-1086/ux-cleanup-fix-openapi-specs-enum-input-validation-error-responses